### PR TITLE
Include <string.h> for strcmp()

### DIFF
--- a/play-audio.cpp
+++ b/play-audio.cpp
@@ -4,6 +4,7 @@
 #include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
 #include <unistd.h>
 #include <SLES/OpenSLES.h>
 #include <SLES/OpenSLES_Android.h>


### PR DESCRIPTION
Fixes building with current clang:

> error: use of undeclared identifier 'strcmp'